### PR TITLE
z3: use Z3_get_error_msg instead of Z3_get_error_msg_ex

### DIFF
--- a/z3/context.go
+++ b/z3/context.go
@@ -61,7 +61,7 @@ type contextImpl struct {
 
 //export goZ3ErrorHandler
 func goZ3ErrorHandler(ctx C.Z3_context, e C.Z3_error_code) {
-	msg := C.Z3_get_error_msg_ex(ctx, e)
+	msg := C.Z3_get_error_msg(ctx, e)
 	// TODO: Lift the Z3 errors to better Go errors. At least wrap
 	// the string in a type and consider using the error code to
 	// determine which of different error types to use.


### PR DESCRIPTION
This PR fixes compile failure caused by the use of `Z3_get_error_msg_ex`.
The API function was long deprecated and existed as an alias to `Z3_get_error_msg`, but it was finally removed from the header in the latest release of Z3. https://github.com/Z3Prover/z3/releases/tag/z3-4.8.1