### PR TITLE
z3: fix compile failure

### DIFF
--- a/z3/bv.go
+++ b/z3/bv.go
@@ -335,11 +335,11 @@ func (lit BV) AsUint64() (val uint64, isLiteral, ok bool) {
 
 // SToInt converts signed bit-vector l to an integer.
 //
-//wrap:expr SToInt:Int l : Z3_mk_bv2int l "C.Z3_TRUE"
+//wrap:expr SToInt:Int l : Z3_mk_bv2int l "true"
 
 // UToInt converts unsigned bit-vector l to an integer.
 //
-//wrap:expr UToInt:Int l : Z3_mk_bv2int l "C.Z3_FALSE"
+//wrap:expr UToInt:Int l : Z3_mk_bv2int l "false"
 
 // IEEEToFloat converts l into a floating-point number, interpreting l
 // in IEEE 754-2008 format.

--- a/z3/bv.wrap.go
+++ b/z3/bv.wrap.go
@@ -533,7 +533,7 @@ func (l BV) SToInt() Int {
 	// Generated from bv.go:338.
 	ctx := l.ctx
 	val := wrapValue(ctx, func() C.Z3_ast {
-		return C.Z3_mk_bv2int(ctx.c, l.c, C.Z3_TRUE)
+		return C.Z3_mk_bv2int(ctx.c, l.c, true)
 	})
 	runtime.KeepAlive(l)
 	return Int(val)
@@ -544,7 +544,7 @@ func (l BV) UToInt() Int {
 	// Generated from bv.go:342.
 	ctx := l.ctx
 	val := wrapValue(ctx, func() C.Z3_ast {
-		return C.Z3_mk_bv2int(ctx.c, l.c, C.Z3_FALSE)
+		return C.Z3_mk_bv2int(ctx.c, l.c, false)
 	})
 	runtime.KeepAlive(l)
 	return Int(val)

--- a/z3/expr.go
+++ b/z3/expr.go
@@ -14,6 +14,7 @@ import (
 #cgo LDFLAGS: -lz3
 #include <z3.h>
 #include <stdlib.h>
+#include <stdint.h>
 */
 import "C"
 
@@ -142,7 +143,7 @@ func (ctx *Context) FromInt(val int64, sort Sort) Value {
 	sval := wrapValue(ctx, func() C.Z3_ast {
 		// Z3_mk_int64 doesn't say real sorts are accepted,
 		// but the C++ bindings use it for reals.
-		return C.Z3_mk_int64(ctx.c, C.__int64(val), sort.c)
+		return C.Z3_mk_int64(ctx.c, C.int64_t(val), sort.c)
 	})
 	runtime.KeepAlive(sort)
 	return sval.lift(sort.Kind())
@@ -226,7 +227,7 @@ func (expr *valueImpl) asInt64() (val int64, isLiteral, ok bool) {
 	if expr.astKind() != C.Z3_NUMERAL_AST {
 		return 0, false, false
 	}
-	var cval C.__int64
+	var cval C.int64_t
 	expr.ctx.do(func() {
 		ok = z3ToBool(C.Z3_get_numeral_int64(expr.ctx.c, expr.c, &cval))
 	})
@@ -242,7 +243,7 @@ func (expr *valueImpl) asUint64() (val uint64, isLiteral, ok bool) {
 	if expr.astKind() != C.Z3_NUMERAL_AST {
 		return 0, false, false
 	}
-	var cval C.__uint64
+	var cval C.uint64_t
 	expr.ctx.do(func() {
 		ok = z3ToBool(C.Z3_get_numeral_uint64(expr.ctx.c, expr.c, &cval))
 	})

--- a/z3/finite.go
+++ b/z3/finite.go
@@ -7,6 +7,7 @@ package z3
 /*
 #cgo LDFLAGS: -lz3
 #include <z3.h>
+#include <stdint.h>
 */
 import "C"
 
@@ -36,7 +37,7 @@ func (ctx *Context) FiniteDomainSort(name string, n uint64) Sort {
 	sym := ctx.symbol(name)
 	var sort Sort
 	ctx.do(func() {
-		sort = wrapSort(ctx, C.Z3_mk_finite_domain_sort(ctx.c, sym, C.__uint64(n)), KindFiniteDomain)
+		sort = wrapSort(ctx, C.Z3_mk_finite_domain_sort(ctx.c, sym, C.uint64_t(n)), KindFiniteDomain)
 	})
 	return sort
 }

--- a/z3/float.go
+++ b/z3/float.go
@@ -331,7 +331,7 @@ exact:
 		// exponent, but a shifted significand with the
 		// most-significant bit stripped.
 		out := Float(wrapValue(ctx, func() C.Z3_ast {
-			return C.Z3_mk_fpa_numeral_int64_uint64(ctx.c, boolToZ3(neg), C.__int64(exp+lost), C.__uint64(val<<(uint(sbits)-exp-1)), sort.c)
+			return C.Z3_mk_fpa_numeral_int64_uint64(ctx.c, boolToZ3(neg), C.int64_t(exp+lost), C.uint64_t(val<<(uint(sbits)-exp-1)), sort.c)
 		}))
 		runtime.KeepAlive(ctx)
 		return out
@@ -466,7 +466,7 @@ func (lit Float) AsBigFloat() (val *big.Float, isLiteral bool) {
 	case lit.isAppOf(C.Z3_OP_FPA_NUM):
 		var sign C.int
 		var sig string
-		var exp C.__int64
+		var exp C.int64_t
 		lit.ctx.do(func() {
 			C.Z3_fpa_get_numeral_sign(lit.ctx.c, lit.c, &sign)
 			sig = C.GoString(C.Z3_fpa_get_numeral_significand_string(lit.ctx.c, lit.c))

--- a/z3/float.go
+++ b/z3/float.go
@@ -470,7 +470,7 @@ func (lit Float) AsBigFloat() (val *big.Float, isLiteral bool) {
 		lit.ctx.do(func() {
 			C.Z3_fpa_get_numeral_sign(lit.ctx.c, lit.c, &sign)
 			sig = C.GoString(C.Z3_fpa_get_numeral_significand_string(lit.ctx.c, lit.c))
-			C.Z3_fpa_get_numeral_exponent_int64(lit.ctx.c, lit.c, &exp, C.Z3_FALSE)
+			C.Z3_fpa_get_numeral_exponent_int64(lit.ctx.c, lit.c, &exp, false)
 		})
 		out.Parse(sig, 10)
 		if sign > 0 {

--- a/z3/package.go
+++ b/z3/package.go
@@ -60,9 +60,9 @@ func boolToZ3(b bool) C.Z3_bool {
 	if b {
 		return C.Z3_TRUE
 	}
-	return C.Z3_FALSE
+	return false
 }
 
 func z3ToBool(b C.Z3_bool) bool {
-	return b != C.Z3_FALSE
+	return b != false
 }


### PR DESCRIPTION
In addition to #4, this PR fixes two issues that lead to build errors with Z3 4.8.1.

(1) Remove use of `__uint64` and `__int64` (commit: b40c8028126d002ec680d87d240644a385d298a5)
These two types were once defined in `z3_api.h` but removed since version 4.7.1 (https://github.com/Z3Prover/z3/pull/1557).

(2) Use `true`/`false` instead of `Z3_TRUE`/`Z3_FALSE` (commit: 576de5295370b38884931cc2dbe99a50d89a32ce)
`Z3_TRUE` and `Z3_FALSE` are interpreted as integer so they cannot be passed to functions that take `Z3_bool` values. We can just use `true`/`false` (Go literals) instead.

I think I should have put my two PRs together. Sorry to bother you.