### PR TITLE
Update bindings for recent z3

### DIFF
--- a/z3/bv.wrap.go
+++ b/z3/bv.wrap.go
@@ -533,7 +533,7 @@ func (l BV) SToInt() Int {
 	// Generated from bv.go:338.
 	ctx := l.ctx
 	val := wrapValue(ctx, func() C.Z3_ast {
-		return C.Z3_mk_bv2int(ctx.c, l.c, C.Z3_TRUE)
+		return C.Z3_mk_bv2int(ctx.c, l.c, C.Z3_bool(true))
 	})
 	runtime.KeepAlive(l)
 	return Int(val)
@@ -544,7 +544,7 @@ func (l BV) UToInt() Int {
 	// Generated from bv.go:342.
 	ctx := l.ctx
 	val := wrapValue(ctx, func() C.Z3_ast {
-		return C.Z3_mk_bv2int(ctx.c, l.c, C.Z3_FALSE)
+		return C.Z3_mk_bv2int(ctx.c, l.c, C.Z3_bool(false))
 	})
 	runtime.KeepAlive(l)
 	return Int(val)

--- a/z3/context.go
+++ b/z3/context.go
@@ -61,7 +61,7 @@ type contextImpl struct {
 
 //export goZ3ErrorHandler
 func goZ3ErrorHandler(ctx C.Z3_context, e C.Z3_error_code) {
-	msg := C.Z3_get_error_msg_ex(ctx, e)
+	msg := C.Z3_get_error_msg(ctx, e)
 	// TODO: Lift the Z3 errors to better Go errors. At least wrap
 	// the string in a type and consider using the error code to
 	// determine which of different error types to use.

--- a/z3/expr.go
+++ b/z3/expr.go
@@ -142,7 +142,7 @@ func (ctx *Context) FromInt(val int64, sort Sort) Value {
 	sval := wrapValue(ctx, func() C.Z3_ast {
 		// Z3_mk_int64 doesn't say real sorts are accepted,
 		// but the C++ bindings use it for reals.
-		return C.Z3_mk_int64(ctx.c, C.__int64(val), sort.c)
+		return C.Z3_mk_int64(ctx.c, C.int64_t(val), sort.c)
 	})
 	runtime.KeepAlive(sort)
 	return sval.lift(sort.Kind())
@@ -226,7 +226,7 @@ func (expr *valueImpl) asInt64() (val int64, isLiteral, ok bool) {
 	if expr.astKind() != C.Z3_NUMERAL_AST {
 		return 0, false, false
 	}
-	var cval C.__int64
+	var cval C.int64_t
 	expr.ctx.do(func() {
 		ok = z3ToBool(C.Z3_get_numeral_int64(expr.ctx.c, expr.c, &cval))
 	})
@@ -242,7 +242,7 @@ func (expr *valueImpl) asUint64() (val uint64, isLiteral, ok bool) {
 	if expr.astKind() != C.Z3_NUMERAL_AST {
 		return 0, false, false
 	}
-	var cval C.__uint64
+	var cval C.uint64_t
 	expr.ctx.do(func() {
 		ok = z3ToBool(C.Z3_get_numeral_uint64(expr.ctx.c, expr.c, &cval))
 	})

--- a/z3/finite.go
+++ b/z3/finite.go
@@ -36,7 +36,7 @@ func (ctx *Context) FiniteDomainSort(name string, n uint64) Sort {
 	sym := ctx.symbol(name)
 	var sort Sort
 	ctx.do(func() {
-		sort = wrapSort(ctx, C.Z3_mk_finite_domain_sort(ctx.c, sym, C.__uint64(n)), KindFiniteDomain)
+		sort = wrapSort(ctx, C.Z3_mk_finite_domain_sort(ctx.c, sym, C.uint64_t(n)), KindFiniteDomain)
 	})
 	return sort
 }

--- a/z3/float.go
+++ b/z3/float.go
@@ -285,14 +285,8 @@ func (ctx *Context) floatFromInt(val int64, sort Sort) Float {
 				val = up
 			}
 		case RoundToNearestAway:
-			// Despite the name, Z3 implements this as
-			// "round to nearest odd". Bug in Z3?
 			if val == mid {
-				if down&1 == 0 {
-					val = up
-				} else {
-					val = down
-				}
+				val = up
 			} else if val < mid {
 				val = down
 			} else {
@@ -331,7 +325,7 @@ exact:
 		// exponent, but a shifted significand with the
 		// most-significant bit stripped.
 		out := Float(wrapValue(ctx, func() C.Z3_ast {
-			return C.Z3_mk_fpa_numeral_int64_uint64(ctx.c, boolToZ3(neg), C.__int64(exp+lost), C.__uint64(val<<(uint(sbits)-exp-1)), sort.c)
+			return C.Z3_mk_fpa_numeral_int64_uint64(ctx.c, boolToZ3(neg), C.int64_t(exp+lost), C.uint64_t(val<<(uint(sbits)-exp-1)), sort.c)
 		}))
 		runtime.KeepAlive(ctx)
 		return out
@@ -399,11 +393,7 @@ func (ctx *Context) floatFromBigInt(val *big.Int, sort Sort) Float {
 		case RoundToNearestAway:
 			switch x.Cmp(&mid) {
 			case 0:
-				if down.Bit(0) == 0 {
-					x = up
-				} else {
-					x = down
-				}
+				x = up
 			case -1:
 				x = down
 			case 1:
@@ -466,11 +456,11 @@ func (lit Float) AsBigFloat() (val *big.Float, isLiteral bool) {
 	case lit.isAppOf(C.Z3_OP_FPA_NUM):
 		var sign C.int
 		var sig string
-		var exp C.__int64
+		var exp C.int64_t
 		lit.ctx.do(func() {
 			C.Z3_fpa_get_numeral_sign(lit.ctx.c, lit.c, &sign)
 			sig = C.GoString(C.Z3_fpa_get_numeral_significand_string(lit.ctx.c, lit.c))
-			C.Z3_fpa_get_numeral_exponent_int64(lit.ctx.c, lit.c, &exp, C.Z3_FALSE)
+			C.Z3_fpa_get_numeral_exponent_int64(lit.ctx.c, lit.c, &exp, C.Z3_bool(false))
 		})
 		out.Parse(sig, 10)
 		if sign > 0 {

--- a/z3/float_test.go
+++ b/z3/float_test.go
@@ -87,7 +87,7 @@ func TestFloatRound(t *testing.T) {
 		for rm, want := range test.res {
 			fr := f.Round(RoundingMode(rm))
 			if !simplifyBool(t, ctx, fr.Eq(ctx.FromInt(want, s).(Float))) {
-				t.Fatal("Round(%g, %s) = %s, want %d", test.val, RoundingMode(rm), fr, want)
+				t.Fatalf("Round(%g, %v) = %s, want %d", test.val, RoundingMode(rm), fr, want)
 			}
 		}
 	}

--- a/z3/helper_test.go
+++ b/z3/helper_test.go
@@ -45,7 +45,7 @@ func simplifyBool(t *testing.T, ctx *Context, x Bool) bool {
 	y := ctx.Simplify(x, nil).(Bool)
 	eq, ok := y.AsBool()
 	if !ok {
-		t.Fatal("Simplify(%s) = %s, want bool literal", x, y)
+		t.Fatalf("Simplify(%s) = %s, want bool literal", x, y)
 	}
 	return eq
 }

--- a/z3/package.go
+++ b/z3/package.go
@@ -58,11 +58,11 @@ import "C"
 
 func boolToZ3(b bool) C.Z3_bool {
 	if b {
-		return C.Z3_TRUE
+		return C.Z3_bool(true)
 	}
-	return C.Z3_FALSE
+	return C.Z3_bool(false)
 }
 
 func z3ToBool(b C.Z3_bool) bool {
-	return b != C.Z3_FALSE
+	return b != C.Z3_bool(false)
 }


### PR DESCRIPTION
The current version of go-z3 doesn't build with the latest z3 (4.8.13). This PR makes some fixes so that it does.

* Some changes to true/false constants and sized int types.
* `Z3_get_error_msg_ex` was renamed to `Z3_get_error_msg`.
* Z3 fixed its implementation of RoundToNearestAway, so the version here needs to be updated to match.